### PR TITLE
Fix DeepSeek spelling

### DIFF
--- a/services/transaction_service.py
+++ b/services/transaction_service.py
@@ -39,7 +39,7 @@ def batch_categorize_transactions(transactions_to_categorize: list) -> dict:
         return {}
 
     print(
-        f"Batch categorizing {len(transactions_to_categorize)} transactions with Deepseek..."
+        f"Batch categorizing {len(transactions_to_categorize)} transactions with DeepSeek..."
     )
 
     transaction_list_str = "\n".join(


### PR DESCRIPTION
## Summary
- correct DeepSeek spelling in batch categorization log message

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6847243c7928832e8c28a226bf9c778e