### PR TITLE
Update ask_agent test docstring

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -5,8 +5,10 @@ from unittest.mock import patch, MagicMock
 
 @patch("agent.agent.get_processed_transactions")
 def test_ask_agent_not_empty(mock_get_transactions):
-    """
-    Tests that the ask_agent function returns a non-empty response.
+    """Tests that ``ask_agent`` returns a non-empty response and cost info.
+
+    ``ask_agent`` now returns a tuple ``(response, cost_info)`` rather than
+    only the response string.
     """
     # Mock the transaction data to avoid Plaid calls
     mock_get_transactions.return_value = ([], [], None)


### PR DESCRIPTION
## Summary
- update test docstring to clarify that `ask_agent` returns `(response, cost_info)`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684724444b44832e9a6fadbda8ff0755