### PR TITLE
Refactor AI assistant to use OpenAI chat API, adjust Plaid country code, and fix Plaid link UI flow

### DIFF
--- a/convex/aiAssistant.ts
+++ b/convex/aiAssistant.ts
@@ -3,19 +3,8 @@
 import { action, internalAction } from "./_generated/server";
 import { v } from "convex/values";
 import { getAuthUserId } from "@convex-dev/auth/server";
-import { api, internal } from "./_generated/api";
-import { ChatOpenAI } from "@langchain/openai";
-import { HumanMessage, SystemMessage } from "@langchain/core/messages";
+import { api } from "./_generated/api";
 import { OpenAI } from "openai";
-
-const llm = new ChatOpenAI({
-  modelName: "deepseek/deepseek-chat-v3-0324:free",
-  openAIApiKey: process.env.OPENROUTER_API_KEY,
-  configuration: {
-    baseURL: "https://openrouter.ai/api/v1",
-  },
-  temperature: 0.1,
-});
 
 const openai = new OpenAI({
   apiKey: process.env.OPENROUTER_API_KEY,
@@ -47,16 +36,6 @@ export const askFinancialQuestion = action({
         ctx.runQuery(api.plaidData.getPlaidTransactions, { limit: 50 }),
       ]);
 
-      // Create context for the AI
-      const financialContext = {
-        monthlyStats,
-        transactions: transactions.slice(0, 20), // Limit for token efficiency
-        budgets,
-        goals,
-        plaidTransactions: plaidTransactions.slice(0, 20),
-        currentDate: currentDate.toISOString().split('T')[0],
-      };
-
       const systemPrompt = `You are a professional personal-finance advisor. Using the data supplied, craft concise, actionable answers in a clear business tone (no emojis, no markdown code fences).  
 • Focus on insights, recommendations, and explanations grounded in the numbers.  
 • When showing money, format as USD currency (e.g. $1,234.56).  
@@ -69,16 +48,14 @@ Income: $${monthlyStats.totalIncome}
 Expenses: $${monthlyStats.totalExpenses}  
 Net Income: $${monthlyStats.netIncome}  
 Transactions: ${transactions.length}  
+Linked Bank Transactions: ${plaidTransactions.length}  
 Budgets: ${budgets.length}  
 Goals: ${goals.length}`;
 
-      const messages = [
-        new SystemMessage(systemPrompt),
-        new HumanMessage(args.question),
-      ];
+      const messages = createAdvisorMessages(systemPrompt, args.question);
 
-      const response = await llm.invoke(messages);
-      return cleanResponse(response.content as string);
+      const response = await generateAdvisorResponse(messages, 0.1);
+      return cleanResponse(response);
     } catch (error) {
       console.error('Error in AI assistant:', error);
       return "I'm sorry, I encountered an error while processing your question. Please try again later.";
@@ -114,13 +91,13 @@ Transactions: ${monthlyStats.transactionCount}
 Budgets: ${budgets.length}  
 Goals: ${goals.length}`;
 
-      const messages = [
-        new SystemMessage(systemPrompt),
-        new HumanMessage("Please generate a financial summary for this month."),
-      ];
+      const messages = createAdvisorMessages(
+        systemPrompt,
+        "Please generate a financial summary for this month.",
+      );
 
-      const response = await llm.invoke(messages);
-      return cleanResponse(response.content as string);
+      const response = await generateAdvisorResponse(messages, 0.1);
+      return cleanResponse(response);
     } catch (error) {
       console.error('Error generating summary:', error);
       return "Unable to generate financial summary at this time.";
@@ -244,7 +221,34 @@ function cleanResponse(text: string): string {
   return text
     .replace(/^```[\s\S]*?```/g, "") // remove fenced blocks
     .split("\n")
-    .map((line) => line.replace(/^\s*([*•\-\/]{1,2}\s*)/, "").trimEnd())
+    .map((line) => line.replace(/^\s*([*•\-/]{1,2}\s*)/, "").trimEnd())
     .join("\n")
     .trim();
+}
+
+async function generateAdvisorResponse(
+  messages: Array<{ role: "system" | "user"; content: string }>,
+  temperature = 0.1,
+): Promise<string> {
+  const response = await openai.chat.completions.create({
+    model: "google/gemini-flash-1.5",
+    temperature,
+    messages,
+  });
+
+  const content = response.choices[0]?.message?.content;
+  if (!content) {
+    throw new Error("No content in AI response");
+  }
+
+  return typeof content === "string"
+    ? content
+    : content.map((part) => ("text" in part ? part.text : "")).join("\n");
+}
+
+function createAdvisorMessages(systemPrompt: string, userPrompt: string) {
+  return [
+    { role: "system" as const, content: systemPrompt },
+    { role: "user" as const, content: userPrompt },
+  ];
 }

--- a/convex/plaid.ts
+++ b/convex/plaid.ts
@@ -38,7 +38,7 @@ export const createLinkToken = action({
         },
         client_name: "Personal Finance App",
         products: [Products.Transactions],
-        country_codes: [CountryCode.Ca],
+        country_codes: [CountryCode.Us],
         language: 'en',
       });
 

--- a/src/components/BankConnection.tsx
+++ b/src/components/BankConnection.tsx
@@ -38,12 +38,15 @@ export function BankConnection() {
       toast.error("Failed to link bank account. Please try again.");
     } finally {
       setIsConnecting(false);
+      setLinkToken(null);
     }
-  }, [exchangePublicToken, accounts]);
+  }, [exchangePublicToken]);
 
   const { open, ready } = usePlaidLink({
     token: linkToken,
-    onSuccess: handleSuccess,
+    onSuccess: (publicToken) => {
+      void handleSuccess(publicToken);
+    },
     onExit: () => {
       setIsConnecting(false);
     },
@@ -89,7 +92,9 @@ export function BankConnection() {
 
       <div className="mt-6 flex gap-4">
         <button
-          onClick={handleConnect}
+          onClick={() => {
+            void handleConnect();
+          }}
           disabled={isConnecting}
           className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors disabled:bg-blue-400 disabled:cursor-not-allowed flex items-center"
         >
@@ -103,7 +108,9 @@ export function BankConnection() {
           )}
         </button>
         <button
-          onClick={handleMigrate}
+          onClick={() => {
+            void handleMigrate();
+          }}
           disabled={isMigrating}
           className="bg-green-600 text-white px-4 py-2 rounded-lg hover:bg-green-700 transition-colors disabled:bg-gray-400"
         >


### PR DESCRIPTION
### Motivation
- Replace the previous LangChain-based LLM integration with direct OpenAI chat calls for simpler, unified model usage and more control over request/response handling. 
- Ensure Plaid is configured for US development instead of Canada to match expected user base. 
- Improve the Plaid linking UI flow and promise handling to prevent unresolved async behavior and clear ephemeral tokens.

### Description
- Removed `ChatOpenAI`, `HumanMessage`, and `SystemMessage` usage and added `generateAdvisorResponse` and `createAdvisorMessages` helpers that call `openai.chat.completions.create` for assistant responses, and updated the assistant actions to use these helpers. 
- Included `Linked Bank Transactions` count in the AI system prompt and tightened response cleaning by adjusting the `cleanResponse` regex. 
- Replaced Plaid `country_codes` from `CountryCode.Ca` to `CountryCode.Us`. 
- Fixed Plaid link UI callbacks by clearing `linkToken` after success (`setLinkToken(null)`), wrapping async handlers with `void` to avoid unhandled promise warnings, and simplified the `onSuccess` handler passed to `usePlaidLink`. 
- Removed an unused import (`internal`) and other obsolete code paths and unified the chat model usage to `google/gemini-flash-1.5` where appropriate.

### Testing
- Ran the TypeScript build with `npm run build`, which completed successfully. 
- Executed the test suite with `npm test`, and all unit tests passed. 
- Ran linting via `npm run lint`, and no new lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f23f9fa1d0832e8553f3cdf461297d)